### PR TITLE
Append etag to response object on the read method

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -85,7 +85,7 @@ const SinkGCS = class SinkGCS {
                 if (response.statusCode === 200) {
                     streamClosed = false;
                     const file = new ReadFile({
-                        etag: '',
+                        etag: response.headers.etag,
                     });
                     file.stream = gcsStream;
                     resolve(file);

--- a/test/main.js
+++ b/test/main.js
@@ -134,6 +134,10 @@ test('Sink() - .read() - File exists', async t => {
         'string',
         'should resolve with a ReadFile object which has a .etag property',
     );
+    t.true(
+        readFrom.etag.length !== 0,
+        'should resolve with a ReadFile object which has a .etag property which is not empty',
+    );
 
     const result = await pipeInto(readFrom.stream);
 


### PR DESCRIPTION
This appends a etag value on the response object on the `.read()` method. Will be further used to write etags in the http server.

~~NB: tests fail due to missing GCS secrets in actions. They pass locally so please ignore until secrets is added to actions.~~ Fixed by #16 