### PR TITLE
Fix typos and improve examples and descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A sink for writing to and reading from [Google Cloud Storage][gcs].
 [![GitHub Actions status](https://github.com/eik-lib/sink-gcs/workflows/Run%20Lint%20and%20Tests/badge.svg)](https://github.com/eik-lib/sink-gcs/actions?query=workflow%3A%22Run+Lint+and+Tests%22)
 [![Known Vulnerabilities](https://snyk.io/test/github/eik-lib/sink-gcs/badge.svg?targetFile=package.json)](https://snyk.io/test/github/eik-lib/sink-gcs?targetFile=package.json)
 
-The intention of the [Eik][eik] sink modules is to be able to write and read files
-to  different backends by swapping sink modules. Because each sink implements the
-same public API it is possible to use this sink in one environment and another sink
-in another environment.
+The intention of the [Eik][eik] sink modules is to be able to write to and read from
+files in different storage backends by swapping sink modules. Because each sink
+implements the same public API it is possible to use this sink in one environment and
+another sink in a different environment.
 
 ## Installation
 
@@ -19,7 +19,7 @@ $ npm install @eik/sink-gcs
 
 ## Example
 
-Read an file from [Google Cloud Storage][gcs] and serve it on http:
+Read a file from [Google Cloud Storage][gcs] and serve it on HTTP:
 
 ```js
 const { pipeline } = require('stream');
@@ -73,13 +73,13 @@ An options object containing configuration. The following values can be provided
 
 ## API
 
-The Sink instance has the following API:
+The sink instance has the following API:
 
 ### .write(filePath, contentType)
 
 Async method for writing a file to storage.
 
-The method takes the following arguments:
+This method takes the following arguments:
 
 * `filePath` - String - Path to the file to be stored - Required.
 * `contentType` - String - The content type of the file - Required.
@@ -87,8 +87,11 @@ The method takes the following arguments:
 Resolves with a writable stream.
 
 ```js
+const { pipeline } = require('stream);
+
 const fromStream = new SomeReadableStream();
 const sink = new Sink({ ... });
+
 try {
     const file = await sink.write('/path/to/file/file.js', 'application/javascript');
     pipeline(fromStream, file.stream, (error) => {
@@ -103,13 +106,20 @@ try {
 
 Async method for reading a file from storage.
 
-The method takes the following arguments:
+This method takes the following arguments:
 
 * `filePath` - String - Path to the file to be read - Required.
 
+Resolves with a [ReadFile][read-file] object which holds metadata about
+the file and a readable stream with the byte stream of the file on the
+`.stream` property.
+
 ```js
+const { pipeline } = require('stream);
+
 const toStream = new SomeWritableStream();
 const sink = new Sink({ ... });
+
 try {
     const file = await sink.read('/path/to/file/file.js');
     pipeline(file.stream, toStream, (error) => {
@@ -122,9 +132,9 @@ try {
 
 ### .delete(filePath)
 
-Async method for deleting a file on the storage.
+Async method for deleting a file in storage.
 
-The method takes the following arguments:
+This method takes the following arguments:
 
 * `filePath` - String - Path to the file to be deleted - Required.
 
@@ -132,6 +142,7 @@ Resolves if file is deleted and rejects if file could not be deleted.
 
 ```js
 const sink = new Sink({ ... });
+
 try {
     await sink.delete('/path/to/file/file.js');
 } catch (error) {
@@ -143,14 +154,15 @@ try {
 
 Async method for checking if a file exist in the storage.
 
-The method takes the following arguments:
+This method takes the following arguments:
 
 * `filePath` - String - Path to the file to be checked for existence - Required.
 
-Resolves if file exist and rejects if file does not exist.
+Resolves if file exists and rejects if file does not exist.
 
 ```js
 const sink = new Sink({ ... });
+
 try {
     await sink.exist('/path/to/file/file.js');
 } catch (error) {
@@ -183,3 +195,4 @@ SOFTWARE.
 [eik]: https://github.com/eik-lib
 [gcs-auth]: https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/0.50.0/google-cloud
 [gcs]: https://cloud.google.com/storage/
+[read-file]: https://github.com/eik-lib/common/blob/master/lib/classes/read-file.js


### PR DESCRIPTION
Fix misc typos and issues addressed in https://github.com/eik-lib/sink-gcs/pull/17.

Comments on @digitalsadhu questions:

> So the API is that sink.read returns a promise but that promise has a stream property? where is the actual file data in this example? In the pipeline callback?

A sink's `.read()` method returns a Promise. This makes it possible for the sink to do async operations before it starts providing a stream of data. In some cases this might be looking up info about a file (ex; mime type) in a meta database, before it starts reading the actual byte stream of the file.

When resolving, the `.read()` method must resolve with a [ReadFile](https://github.com/eik-lib/common/blob/master/lib/classes/read-file.js) object. This object holds metadata about the file (such as etag as mime type) plus a `.stream` property which must be a readable stream providing the byte stream of the file.

By doing it so its possible for the sink to do misc operations in a async manner before it starts streaming data. This makes it possible for the HTTP layer further up in Eik to get information about a file at the same time as the byte stream of the file is available without knowing about any of the logic the sink has to do to provide a byte stream and any related metadata to the file. This makes it a lot easier in the upper layers of Eik to ex set HTTP headers etc in a predecible manner.