### PR TITLE
Make it possible to set the full GCS storage options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,17 @@ const sink = new Sink({
     credentials: {
         client_email: 'a@email.address',
         private_key: '[ ...snip... ]',
-        projectId: 'myProject',
     },
+    projectId: 'myProject',
 });
 ```
 
-### options
+This constructor takes the following arguments:
 
-An options object containing configuration. The following values can be provided:
-
-* `.credentials` - Object - A Google Cloud Storage [auth object][gcs-auth] - Required.
+ * `storageOptions` - Object - A Google Cloud Storage [storage options object][gcs-storage-options] - Required.
+ * `sinkOptions` - Object - An options object for the sink - See properties below - Optional.
+ * `sinkOptions.rootPath` - String - Root directory for where to store files in the GCS bucket - Default: `eik` - Optional.
+ * `sinkOptions.bucket` - String - Name of the bucket to store files in - Default: `eik_files` - Optional.
 
 ## API
 
@@ -194,5 +195,6 @@ SOFTWARE.
 
 [eik]: https://github.com/eik-lib
 [gcs-auth]: https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/0.50.0/google-cloud
+[gcs-storage-options]: https://googleapis.dev/nodejs/storage/latest/global.html#StorageOptions
 [gcs]: https://cloud.google.com/storage/
 [read-file]: https://github.com/eik-lib/common/blob/master/lib/classes/read-file.js

--- a/lib/main.js
+++ b/lib/main.js
@@ -15,17 +15,13 @@ const DEFAULT_BUCKET = 'eik_files';
  */
 
 const SinkGCS = class SinkGCS {
-    constructor({
-        projectId,
+    constructor(storageOptions, {
         rootPath = DEFAULT_ROOT_PATH,
         bucket = DEFAULT_BUCKET,
-        credentials = {},
     } = {}) {
+        if (typeof storageOptions !== 'object' || storageOptions === null) throw new Error('"storageOptions" argument must be provided');;
         this._rootPath = rootPath;
-        this._storage = new Storage({
-            credentials,
-            projectId,
-        });
+        this._storage = new Storage(storageOptions);
         this._bucket = this._storage.bucket(bucket);
     }
 

--- a/test/main.js
+++ b/test/main.js
@@ -73,6 +73,22 @@ test('Sink() - Object type', t => {
     t.end();
 });
 
+test('Sink() - Argument "storageOptions" not provided' , t => {
+    t.plan(1);
+    t.throws(() => {
+        const sink = new Sink(); // eslint-disable-line no-unused-vars
+    }, /"storageOptions" argument must be provided/, 'Should throw');
+    t.end();
+});
+
+test('Sink() - Argument "storageOptions" is of wrong type', t => {
+    t.plan(1);
+    t.throws(() => {
+        const sink = new Sink('foo'); // eslint-disable-line no-unused-vars
+    }, /"storageOptions" argument must be provided/, 'Should throw');
+    t.end();
+});
+
 test('Sink() - .write()', async t => {
     const sink = new Sink(DEFAULT_CONFIG);
     const dir = slug();


### PR DESCRIPTION
This makes it possible to pass on the full Google Cloud Storage storage options through the constructor of the sink. The advantage of this is that it makes it fully possible for the user to use all the options in the GCS client to authenticate against GCS.