### PR TITLE
Use @eik/sink module

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const { Storage } = require('@google-cloud/storage');
-const { ReadFile, Sink } = require('@eik/common');
+const { ReadFile } = require('@eik/common');
+const Sink = require('@eik/sink');
 const path = require('path');
 
 const DEFAULT_ROOT_PATH = 'eik';

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/eik-lib/sink-gcs.git"
+    "url": "git@github.com:eik-lib/sink-gcs.git"
   },
   "author": "Trygve Lie",
   "license": "MIT",
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/eik-lib/sink-gcs#readme",
   "dependencies": {
     "@google-cloud/storage": "4.7.0",
-    "@eik/common": "1.0.0-alpha.4"
+    "@eik/common": "1.0.0-alpha.6",
+    "@eik/sink": "1.0.0"
   },
   "devDependencies": {
     "eslint": "6.8.0",


### PR DESCRIPTION
This makes use of the new @eik/sink module instead of the sink which was in @eik/common.