### PR TITLE
feat() - Make it possible to configure timeout on write operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ const sink = new Sink({
 This constructor takes the following arguments:
 
  * `storageOptions` - Object - A Google Cloud Storage [storage options object][gcs-storage-options] - Required.
+ * `writeTimeout` - Number - Timeout, in milliseconds, for write operations to the sink - Default: `30000` - Optional.
  * `sinkOptions` - Object - An options object for the sink - See properties below - Optional.
  * `sinkOptions.rootPath` - String - Root directory for where to store files in the GCS bucket - Default: `eik` - Optional.
  * `sinkOptions.bucket` - String - Name of the bucket to store files in - Default: `eik_files` - Optional.

--- a/lib/main.js
+++ b/lib/main.js
@@ -17,11 +17,13 @@ const DEFAULT_BUCKET = 'eik_files';
 
 const SinkGCS = class SinkGCS extends Sink {
     constructor(storageOptions, {
+        writeTimeout = 30000,
         rootPath = DEFAULT_ROOT_PATH,
         bucket = DEFAULT_BUCKET,
     } = {}) {
         super();
         if (typeof storageOptions !== 'object' || storageOptions === null) throw new Error('"storageOptions" argument must be provided');;
+        this._writeTimeout = writeTimeout;
         this._rootPath = rootPath;
         this._storage = new Storage(storageOptions);
         this._bucket = this._storage.bucket(bucket);
@@ -51,6 +53,7 @@ const SinkGCS = class SinkGCS extends Sink {
                     cacheControl: 'public, max-age=31536000',
                     contentType,
                 },
+                timeout: this._writeTimeout,
                 gzip: true,
             });
 

--- a/test/main.js
+++ b/test/main.js
@@ -113,6 +113,20 @@ test('Sink() - .write() - arguments is illegal', async (t) => {
     t.end();
 });
 
+test('Sink() - .write() - timeout', async (t) => {
+    const sink = new Sink(DEFAULT_CONFIG, {
+        writeTimeout: 40,
+    });
+    const dir = slug();
+    const file = `${dir}/bar/map.json`;
+
+    const writeFrom = readFileStream('../fixtures/import-map.json');
+    const writeTo = await sink.write(file, 'application/json');
+
+    t.rejects(pipe(writeFrom, writeTo), /network timeout at/, 'should reject on timeout');
+    t.end();
+});
+
 test('Sink() - .write() - directory traversal prevention', async t => {
     const sink = new Sink(DEFAULT_CONFIG);
     const dir = slug();


### PR DESCRIPTION
Latest version of the GCS client (https://github.com/eik-lib/sink-gcs/pull/37) makes it possible to configure write timeouts: https://github.com/googleapis/nodejs-storage/pull/1208. Expose this through the sink constructor properties.