### PR TITLE
fix: Make gzip compression configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This constructor takes the following arguments:
 
  * `storageOptions` - Object - A Google Cloud Storage [storage options object][gcs-storage-options] - Required.
  * `writeTimeout` - Number - Timeout, in milliseconds, for write operations to the sink - Default: `30000` - Optional.
+ * `writeGzip` - Boolean - If files should be written with gzip compression - Default: `false` - Optional.
  * `sinkOptions` - Object - An options object for the sink - See properties below - Optional.
  * `sinkOptions.rootPath` - String - Root directory for where to store files in the GCS bucket - Default: `eik` - Optional.
  * `sinkOptions.bucket` - String - Name of the bucket to store files in - Default: `eik_files` - Optional.

--- a/lib/main.js
+++ b/lib/main.js
@@ -19,12 +19,14 @@ const DEFAULT_BUCKET = 'eik_files';
 const SinkGCS = class SinkGCS extends Sink {
     constructor(storageOptions, {
         writeTimeout = 30000,
+        writeGzip = false,
         rootPath = DEFAULT_ROOT_PATH,
         bucket = DEFAULT_BUCKET,
     } = {}) {
         super();
         if (typeof storageOptions !== 'object' || storageOptions === null) throw new Error('"storageOptions" argument must be provided');;
         this._writeTimeout = writeTimeout;
+        this._writeGzip = writeGzip;
         this._rootPath = rootPath;
         this._storage = new Storage(storageOptions);
         this._bucket = this._storage.bucket(bucket);
@@ -73,7 +75,7 @@ const SinkGCS = class SinkGCS extends Sink {
                     contentType,
                 },
                 timeout: this._writeTimeout,
-                gzip: true,
+                gzip: this._writeGzip,
             });
 
             gcsStream.on('error', () => {


### PR DESCRIPTION
Makes it possible to configure if files should be written to Google Cloud Storage with gzip compression or not. 

Changes default to `false`. This is done because when serving a compressed file through Fastify it will not be re-compressed. We want Fastify to select compression (brotli, gzip or none) based on what the client supports.