### PR TITLE
fix: No automatic extension resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@eik/sink-gcs",
   "version": "1.2.1",
   "description": "Sink for Google Cloud Storage",
-  "main": "lib/main",
+  "main": "lib/main.js",
   "type": "module",
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
Automatic extension resolution of the "main" field is deprecated for ES modules. This is now causing an deprecation error in modules depending on this module.

Added extension to the exported file in the "main" field.