### PR TITLE
fix: Improve GCS usage

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -135,29 +135,32 @@ const SinkGCS = class SinkGCS extends Sink {
 				return;
 			}
 
-			let streamClosed = true;
+			let resolved = false;
 
 			const src = this._bucket.file(pathname);
 			const gcsStream = src.createReadStream();
 
-			gcsStream.on("readable", () => {
-				gcsStream.read();
-			});
+			// The GCS SDK creates streams lazily; resume() triggers the underlying
+			// HTTP request without consuming data (we pause() again before resolve).
+			gcsStream.resume();
 
 			gcsStream.on("error", (error) => {
-				if (streamClosed) {
-					this._counter.inc({ labels: { access: true, operation } });
+				this._counter.inc({ labels: { access: true, operation } });
+				if (!resolved) {
 					reject(error);
 				}
 			});
 
 			gcsStream.on("response", (response) => {
-				this._counter.inc({
-					labels: { success: true, access: true, operation },
-				});
-
 				if (response.statusCode === 200) {
-					streamClosed = false;
+					resolved = true;
+					// Pause before handing the stream to the consumer. HTTP guarantees
+					// response headers arrive before the body, so no body bytes have
+					// been emitted yet. pause() buffers them until the consumer pipes.
+					gcsStream.pause();
+					this._counter.inc({
+						labels: { success: true, access: true, operation },
+					});
 					const obj = new ReadFile({
 						mimeType: response.headers["content-type"],
 						etag: response.headers.etag,
@@ -165,6 +168,7 @@ const SinkGCS = class SinkGCS extends Sink {
 					obj.stream = gcsStream;
 					resolve(obj);
 				} else {
+					gcsStream.destroy();
 					reject(
 						new Error(
 							`Could not read file. Got http status code ${response.statusCode} from GCS`,
@@ -251,7 +255,7 @@ const SinkGCS = class SinkGCS extends Sink {
 				(/** @type {Error | null} */ error, /** @type {boolean} */ exists) => {
 					if (error) return reject(error);
 					if (exists) return resolve();
-					return reject();
+					return reject(new Error("File does not exist"));
 				},
 			);
 		});

--- a/test/main.js
+++ b/test/main.js
@@ -487,6 +487,20 @@ await test("Sink() - .exist() - Check non existing file", async () => {
 	);
 });
 
+await test("Sink() - .exist() - non-existing file rejects with an Error", async () => {
+	const sink = new Sink(DEFAULT_CONFIG);
+	const dir = slug();
+	await assert.rejects(
+		sink.exist(`/${dir}/foo/not-exist.json`),
+		(err) => {
+			assert.ok(err instanceof Error, "rejection must be an Error instance");
+			assert.ok(err.message.length > 0, "Error must have a non-empty message");
+			return true;
+		},
+		"should reject with an Error instance",
+	);
+});
+
 await test("Sink() - .exist() - arguments is illegal", async () => {
 	const sink = new Sink(DEFAULT_CONFIG);
 	await assert.rejects(


### PR DESCRIPTION
I've been analyzing Eik a bit and found a couple of issues here and there which can be part of some issues we see. 

Some issues found in this module:

## Possible memory leak on failed reads

When GCS returned a non-200 HTTP response the underlying stream is left open. This holds a TCP connection until GCS is done sending the error body which can be up to 60s. This can cause files to hang around.

Fixed by explicitly calling `gcsStream.destroy()` before rejecting the promise (line 171).

## Let consumer of read stream control the stream

When reading files we called `gcsStream.read()` without really using the return value which means we are consuming bytes from the internal buffer and discarding them and for small files this can silently produce empty or truncated responses. 

Fixed by replacing the handler with `gcsStream.resume()` (GCS do create streams lazily and needs something to initiate the HTTP request) to start the request, then `gcsStream.pause()` inside the 200 response handler so the body is buffered rather than dropped while the consumer sets up piping.

## Improve metrics on errors

We used a `streamClosed` flag to prevent the error handler from doing anything once a 200 response arrived. The problem with this is that mid-stream errors (network drop, timeout during body transfer) ended up not being counted. 

Fixed by inverting the flag to `resolved` and always incrementing the counter on error.

## Improve error logging

When a file was not found we call `reject()` with no argument causing all rejections to look similar and making it impossible to distinguish "file not found" from a real GCS error (auth failure, network issue etc).

Fixed by passing `new Error("File does not exist")` to `reject()`. This does also make it consistent with the other sink implementations.
